### PR TITLE
Performance optimisation

### DIFF
--- a/ExcelExportGrailsPlugin.groovy
+++ b/ExcelExportGrailsPlugin.groovy
@@ -1,6 +1,6 @@
 class ExcelExportGrailsPlugin {
     // the plugin version
-    def version = "0.2.2-webnog"
+    def version = "0.2.3-webnog"
     // the version or versions of Grails the plugin is designed for
     def grailsVersion = "2.0 > *"
     // the other plugins this plugin depends on

--- a/ExcelExportGrailsPlugin.groovy
+++ b/ExcelExportGrailsPlugin.groovy
@@ -1,6 +1,6 @@
 class ExcelExportGrailsPlugin {
     // the plugin version
-    def version = "0.2.1"
+    def version = "0.2.2-webnog"
     // the version or versions of Grails the plugin is designed for
     def grailsVersion = "2.0 > *"
     // the other plugins this plugin depends on

--- a/application.properties
+++ b/application.properties
@@ -1,5 +1,5 @@
 #Grails Metadata file
-#Sun Nov 17 11:06:58 CET 2013
-app.grails.version=2.3.2
+#Fri Jan 30 14:44:24 GMT 2015
+app.grails.version=2.3.3
 app.name=excel-export
 app.servlet.version=2.5

--- a/grails-app/conf/BuildConfig.groovy
+++ b/grails-app/conf/BuildConfig.groovy
@@ -45,7 +45,7 @@ grails.project.dependency.resolution = {
         }
     }
     plugins {
-        build ':release:3.1.1', ':rest-client-builder:1.0.3', {
+        build ':release:3.0.1', ':rest-client-builder:1.0.3', {
             export = false
         }
     }

--- a/grails-app/conf/BuildConfig.groovy
+++ b/grails-app/conf/BuildConfig.groovy
@@ -11,6 +11,12 @@ grails.project.dependency.resolution = {
     }
     log "warn" // log level of Ivy resolver, either 'error', 'warn', 'info', 'debug' or 'verbose'
     repositories {
+        inherits true // Whether to inherit repository definitions from plugins
+
+        grailsPlugins()
+        grailsHome()
+        mavenLocal()
+        
         grailsCentral()
         mavenCentral()
 

--- a/grails-app/conf/BuildConfig.groovy
+++ b/grails-app/conf/BuildConfig.groovy
@@ -39,7 +39,7 @@ grails.project.dependency.resolution = {
         }
     }
     plugins {
-        build ':release:2.2.1', ':rest-client-builder:1.0.3', {
+        build ':release:3.1.1', ':rest-client-builder:1.0.3', {
             export = false
         }
     }

--- a/plugin.xml
+++ b/plugin.xml
@@ -1,4 +1,4 @@
-<plugin name='excel-export' version='0.2.1' grailsVersion='2.0 &gt; *'>
+<plugin name='excel-export' version='0.2.2-webnog' grailsVersion='2.0 &gt; *'>
   <author>Jakub Nabrdalik</author>
   <authorEmail>jakubn@gmail.com</authorEmail>
   <title>Excel Export Plugin</title>

--- a/plugin.xml
+++ b/plugin.xml
@@ -1,4 +1,4 @@
-<plugin name='excel-export' version='0.2.2-webnog' grailsVersion='2.0 &gt; *'>
+<plugin name='excel-export' version='0.2.3-webnog' grailsVersion='2.0 &gt; *'>
   <author>Jakub Nabrdalik</author>
   <authorEmail>jakubn@gmail.com</authorEmail>
   <title>Excel Export Plugin</title>

--- a/src/groovy/pl/touk/excel/export/getters/PropertyGetter.groovy
+++ b/src/groovy/pl/touk/excel/export/getters/PropertyGetter.groovy
@@ -25,7 +25,7 @@ abstract class PropertyGetter<From, To> implements Getter<To> {
         if ( object instanceof Map ) {
             return format( object[ propertyName ] )
         } else {
-            if (!object.properties.containsKey(propertyName)) {
+            if (!(object.hasProperty(propertyName) ? true : false)) {
                 return null
             }
             return format(object."$propertyName")
@@ -34,7 +34,7 @@ abstract class PropertyGetter<From, To> implements Getter<To> {
 
     private Object getValueFromChildren(object) {
         def value = propertyName.tokenize('.').inject(object) { Object currentObject, propertyName ->
-            if (!(currentObject instanceof Map) && (currentObject == null || !currentObject.properties.containsKey(propertyName))) {
+            if (!(currentObject instanceof Map) && (currentObject == null || !(currentObject.hasProperty(propertyName) ? true : false))) {
                 return null
             }
             return currentObject."$propertyName"


### PR DESCRIPTION
Performance optimisation changing "object.properties.containsKey(propertyName)" to (object.hasProperty('propertyName') ? true : false);

This uses Groovy Native methods to check if the property is there or not. This saves a hashMap having to be passed back. This can have a time saving especially where the object references other Objects.  On the shouldFillRowAtPosition test I getting an improvement from 1.891 to 0.447. On the other tests I am seeing a performance increase as well.

Changes to be committed:
modified:   src/groovy/pl/touk/excel/export/getters/PropertyGetter.groovy
