### PR TITLE
  [withProperties] More simple exporting my own types

### DIFF
--- a/src/groovy/pl/touk/excel/export/XlsxExporter.groovy
+++ b/src/groovy/pl/touk/excel/export/XlsxExporter.groovy
@@ -39,7 +39,7 @@ class XlsxExporter implements SheetManipulator {
         setUp(workbook)
     }
     XlsxExporter(File f) {
-        XlsxExporter(f.path)
+        this(f.path)
     }
     private XSSFWorkbook createOrLoadWorkbook(String fileNameWithPath) {
         if(new File(fileNameWithPath).exists()) {


### PR DESCRIPTION
[This](https://github.com/TouK/excel-export/blob/master/README.md#how-to-export-my-own-types) resolves handling own types , however , it does not taske benefits of groovy extra-features comparing  with Java . 

My suggestion is to use Closures directly :

```
def withProperties=['name',{it.currency.displayName}]

```
### Instead of  :

creating whole class+ Instantiate it like this . 

```
def withProperties = ['name', new CurrencyGetter('price.currency')]

```
