### PR TITLE
Updating Content-Type per http://filext.com/file-extension/XLSX.  

### DIFF
--- a/src/main/groovy/pl/touk/excel/export/WebXlsxExporter.groovy
+++ b/src/main/groovy/pl/touk/excel/export/WebXlsxExporter.groovy
@@ -30,7 +30,7 @@ class WebXlsxExporter extends XlsxExporter {
 
     private WebXlsxExporter setHeaders(HttpServletResponse response, def filename) {
         response.setHeader("Content-disposition", "attachment; filename=$filename;")
-        response.setHeader("Content-Type", "application/vnd.ms-excel")
+        response.setHeader("Content-Type", "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet")
         this
     }
 }


### PR DESCRIPTION
When downloading the xlxs file using FireFox  it will add .xls to the file if you choose to open it after downloading rather than saving.  So the file filename.xlsx becomes filename.xlsx.xls.  Changing the Content-Type to application/vnd.openxmlformats-officedocument.spreadsheetml.sheet solves this issue.

References:
http://filext.com/file-extension/XLSX
http://stackoverflow.com/questions/974079/setting-mime-type-for-excel-document